### PR TITLE
Do not conditionnalize libisal on default storage policy

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,9 +4,7 @@
   package:
     name: "{{ 'libisal' if ansible_os_family == 'RedHat' else 'libisal2' }}"
     state: present
-  when:
-    - openio_namespace_storage_policy | map('lower') | select('match', 'ecisal') | list
-    - ansible_architecture == 'x86_64'
+  when: ansible_architecture == 'x86_64'
   ignore_errors: "{{ ansible_check_mode }}"
   register: install_packages_isal
   until: install_packages_isal is success


### PR DESCRIPTION
Additionally, the condition was wrong, it should have been:
`{{ (var | lower).startswith('isal') }}`