### PR TITLE
BUGFIX/MAJOR(namespace): Add maintenance mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ An Ansible role for write the file namespace used in OpenIO SDS
 | `openio_namespace_storage_policy` | `"THREECOPIES"` | The storage policy |
 | `openio_namespace_udp_allowed` | `"yes"` | Allow UDP |
 | `openio_namespace_zookeeper_url` | `""` | Tuple of zookeepers addresses and port (comma separated) |
+| `openio_namespace_provision_only` | `false` | Provision only without restarting / bootstrapping |
 
 ## Dependencies
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -8,6 +8,7 @@ openio_namespace_event_agent_url: "beanstalk://{{ ansible_default_ipv4.address }
 openio_namespace_ecd_url: ""
 openio_namespace_meta1_digits: 2
 openio_namespace_udp_allowed: "yes"
+openio_namespace_provision_only: false
 
 openio_namespace_storage_policy: "THREECOPIES"
 openio_namespace_chunk_size_megabytes: 100

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -39,6 +39,7 @@
     gridinit_cmd restart {{ openio_namespace_name }}-oioproxy-0
   when:
     - _ns.changed
+    - not openio_namespace_provision_only
   ignore_errors: true  # oioproxy is not necessarily present
   tags: configure
 ...


### PR DESCRIPTION
 ##### SUMMARY

Lack of maintenance mode in namespace delivery --> reload gridinit even if openio_maintenance_mode is set to true

 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION