### PR TITLE
BUGFIX/MAJOR(namespace): `ecd` in namespace is always comment

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -11,7 +11,7 @@ openio_namespace_zookeeper_url: "{{ openio_zookeeper_addresses_chain \
   | ns_join_by(3) ) }}"
 openio_namespace_oioproxy_url: "{{ openio_bind_address | d(ansible_default_ipv4.address) }}:6006"
 openio_namespace_event_agent_url: "beanstalk://{{ openio_bind_address | d(ansible_default_ipv4.address) }}:6014"
-openio_namespace_ecd_url: "{% if groups.ecd is defined and groups.ecd | bool %}\
+openio_namespace_ecd_url: "{% if groups.ecd is defined and groups.ecd %}\
   {{ openio_bind_address | d(ansible_default_ipv4.address) }}:6017{% endif %}"
 openio_namespace_meta1_digits: "{{ namespace_meta1_digits  | d(2) }}"
 openio_namespace_udp_allowed: "yes"


### PR DESCRIPTION
 ##### SUMMARY

Currently, the ecd part is always comment in the NS file

 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION
```
--- before: /etc/oio/sds.conf.d/OPENIO
+++ after: /home/cedric/.ansible/tmp/ansible-local-16959KE4FS1/tmpN6VZjm/namespace.j2
@@ -5,7 +5,7 @@
 zookeeper=172.17.0.2:6005,172.17.0.33:6005,172.17.0.3:6005
 proxy=172.17.0.33:6006
 event-agent=beanstalk://172.17.0.33:6014
-#ecd=
+ecd=172.17.0.33:6017
```