### PR TITLE
CHANGE(namespace): Increase meta2 distance

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -23,7 +23,7 @@ openio_namespace_service_update_policy:
   - name: meta2
     policy: KEEP
     replicas: 3
-    distance: 1
+    distance: 2
   - name: rdir
     policy: KEEP
     replicas: 1


### PR DESCRIPTION
 ##### SUMMARY
When a server is down, the distance between meta2 deny the push of object.

 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION