### PR TITLE
FEATURE(namespace): Manage url of multi conscience

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,7 +1,30 @@
 # roles/namespace/defaults/main.yml
 ---
 openio_namespace_name: "{{ namespace | default('OPENIO') }}"
-openio_namespace_conscience_url: "{{ openio_bind_virtual_address | d(ansible_default_ipv4.address) }}:6000"
+openio_namespace_conscience_url: >-
+  {% set _var = ansible_default_ipv4.address + ':6000' -%}
+  {% if openio_conscience_multiple_enable | default(false) -%}
+  {%   if groups[openio_namespace_conscience_groupname] is defined -%}
+  {%     if groups[openio_namespace_conscience_groupname] -%}
+  {%       set list_ip = groups[openio_namespace_conscience_groupname]
+                           | map('extract', hostvars, ['openio_bind_address']) | list -%}
+  {%       if inventory_hostname in groups[openio_namespace_conscience_groupname] -%}
+  {%         set _var = openio_bind_address + ':6000,' + list_ip | difference([openio_bind_address])
+                          | map('regex_replace', '$', ':6000') | shuffle(seed=inventory_hostname) | join(',') -%}
+  {%       else -%}
+  {%         set _var = list_ip | difference([openio_bind_address])
+                          | map('regex_replace', '$', ':6000') | shuffle(seed=inventory_hostname) | join(',') -%}
+  {%       endif -%}
+  {%     endif -%}
+  {%   endif -%}
+  {% else -%}
+  {%   if openio_bind_virtual_address is defined -%}
+  {%     set _var = openio_bind_virtual_address + ':6000' -%}
+  {%   endif -%}
+  {% endif -%}
+  {{ _var }}
+
+openio_namespace_conscience_groupname: conscience
 openio_namespace_zookeeper_groupname: zookeeper
 openio_namespace_zookeeper_url: "{{ openio_zookeeper_addresses_chain \
   | default(groups[openio_namespace_zookeeper_groupname] | default([]) \

--- a/docker-tests/test.yml
+++ b/docker-tests/test.yml
@@ -19,21 +19,38 @@
       run_once: true
       changed_when: false
 
+    #- add_host:
+    #    name: "{{ item.name }}"
+    #    ansible_host: "{{ item.openio_bind_address }}"
+    #    openio_bind_address: "{{ item.openio_bind_address }}"
+    #    groups: conscience
+    #  with_items:
+    #    - { name: "node1", openio_bind_address: "172.17.0.2" }
+    #    - { name: "localhost", openio_bind_address: "172.17.0.3" }
+    #    - { name: "node3", openio_bind_address: "172.17.0.4" }
+    #  delegate_to: localhost
+    #  run_once: true
+    #  changed_when: false
+
+
 - hosts: localhost
   become: true
   vars:
     NS: TRAVIS
+    #openio_bind_virtual_address: "172.17.0.100"
+    #openio_bind_address: "172.17.0.3"
+    #openio_conscience_multiple:
+    #  me: "172.17.0.2:6600"
+    #  group:
+    #    - 172.17.0.3:6600
+    #    - 172.17.0.4:6600
   roles:
     - role: users
     - role: repo
-      openio_repository_openstack_release: 'queens'
       openio_repository_no_log: false
-      openio_repository_products:
-        sds:
-          release: "18.10"
+      openio_repository_mirror_host: mirror2.openio.io
     - role: role_under_test
       openio_namespace_name: "{{ NS }}"
-      openio_namespace_conscience_url: "{{ ansible_default_ipv4.address }}:6000"
       openio_namespace_oioproxy_url: "{{ ansible_default_ipv4.address }}:6006"
       openio_namespace_event_agent_url: "beanstalk://{{ ansible_default_ipv4.address }}:6014"
       openio_namespace_ecd_url: "{{ ansible_default_ipv4.address }}:6017"


### PR DESCRIPTION
 ##### SUMMARY

When the multi-conscience is enabled, the conscience's url become a list of addresses separated by commas.

 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION
If the server have a local conscience, its `openio_bind_address` is always on the top of choices.