### PR TITLE
BUGFIX/MINOR(namespace): Fix the use of tags `install` and `configure`

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -10,6 +10,7 @@
   until: install_packages_isal is success
   retries: 5
   delay: 2
+  tags: install
 
 - name: Ensure directories exists
   file:
@@ -20,7 +21,7 @@
     mode: "{{ item.mode | default(0755) }}"
   with_items:
     - path: "/etc/oio/sds.conf.d"
-  tags: install
+  tags: configure
 
 - name: Generate configuration files
   template:


### PR DESCRIPTION
 ##### SUMMARY

It can be useful to prepare images to run only the `install` tag and then only the` configure` tag

 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION