### PR TITLE
BUGFIX/MINOR(namespace): Add `sqliterepo.repo.hard_max` by default

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -31,6 +31,7 @@ openio_namespace_service_update_policy:
 
 openio_namespace_options:
   - "sqliterepo.repo.soft_max=1000"
+  - "sqliterepo.repo.hard_max=1000"
 
 openio_namespace_overwrite: false
 ...


### PR DESCRIPTION
 ##### SUMMARY
To prevent meta2 services using all avalaible memory (OOM-killer bad side effect), we must add parameter sqliterepo.repo.hard_max in our /etc/oio/sds.conf.d/NAMESPACE by default.
It may be calculated but at first we can force it to 1000.
It means that no more than 1000 meta2 databases by meta2 services can be in memory at a time.

 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION
OS-264