### PR TITLE
CHANGE(namespace): Remove duplicated `meta1_digits`

### DIFF
--- a/templates/namespace.j2
+++ b/templates/namespace.j2
@@ -9,7 +9,6 @@ proxy={{ openio_namespace_oioproxy_url }}
 
 udp_allowed={{ openio_namespace_udp_allowed }}
 
-meta1_digits={{ openio_namespace_meta1_digits }}
 ns.meta1_digits={{ openio_namespace_meta1_digits }}
 ns.storage_policy={{ openio_namespace_storage_policy }}
 ns.chunk_size={{ (openio_namespace_chunk_size_megabytes | int) * 1024 * 1024 }}


### PR DESCRIPTION
 ##### SUMMARY

Since 19.04, this parameter is obsolete.

 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION