### PR TITLE
BUGFIX/MINOR(namespace): Add compat with python3

### DIFF
--- a/filter_plugins/namespace.py
+++ b/filter_plugins/namespace.py
@@ -1,4 +1,5 @@
 #!/usr/bin/python
+from six.moves import map
 
 class FilterModule(object):
     def filters(self):
@@ -10,7 +11,7 @@ class FilterModule(object):
     def join_by(self, mylist=[], group_by=3, D=',', d=';'):
         list_grouped_by_comma=[]
         if len(mylist) % group_by == 0:
-            for i in range(len(mylist) / group_by):
+            for i in range(int(len(mylist) / group_by)):
                 list_grouped_by_comma.append(D.join(map(str, mylist[(i * group_by):(i * group_by + group_by)])))
 
         return d.join(map(str, list_grouped_by_comma))


### PR DESCRIPTION
 ##### SUMMARY

In Python 3, the map() function return iterators. In Python 2, it returned lists.
The Compatibility library: `six` library provides the iterator behavior under names common to both Python versions

 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION
```
TASK [namespace : Generate configuration files] *********************************************************
Thursday 07 November 2019  08:25:04 +0000 (0:00:02.029)       0:04:35.710 *****
fatal: [node01]: FAILED! => changed=false
  msg: 'AnsibleError: An unhandled exception occurred while templating ''{{ openio_zookeeper_addresses_chain | default(groups[openio_namespace_zookeeper_groupname] | default([]) | map(''extract'', hostvars, [''openio_bind_address'']) | map(''regex_replace'', ''$'', '':6005'') | list | ns_join_by(3) ) }}''. Error was a <class ''ansible.errors.AnsibleError''>, original message: Unexpected templating type error occurred on ({{ openio_zookeeper_addresses_chain | default(groups[openio_namespace_zookeeper_groupname] | default([]) | map(''extract'', hostvars, [''openio_bind_address'']) | map(''regex_replace'', ''$'', '':6005'') | list | ns_join_by(3) ) }}): ''float'' object cannot be interpreted as an integer'
```