### PR TITLE
BUGFIX/MINOR(namespace): Manages the restart of the oioproxy during the first installation

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -41,6 +41,12 @@
   when:
     - _ns.changed
     - not openio_namespace_provision_only
-  ignore_errors: true  # oioproxy is not necessarily present
+  register: _restart_oioproxy
+  failed_when:
+    - _restart_oioproxy.rc != 0
+    # resource oioproxy not found
+    - not 'No such file or directory' in _restart_oioproxy.stdout
+    # gridinit not found
+    - not 'not found' in _restart_oioproxy.stderr
   tags: configure
 ...


### PR DESCRIPTION

 ##### SUMMARY

Manages ugly ignored error at the first installation.

This error occurs when the namespace file is templatized the first time but the oioproxy is not present yet.

 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION

```console
fatal: [node1]: FAILED! => changed=true
  cmd: |-
    gridinit_cmd reload
    gridinit_cmd restart OPENIO-oioproxy-0
  delta: '0:00:00.007337'
  end: '2020-03-05 14:59:57.755187'
  msg: non-zero return code
  rc: 1
  start: '2020-03-05 14:59:57.747850'
  stderr: ''
  stderr_lines: <omitted>
  stdout: |-
    DONE            obsoleted 2 processes   Success
    DONE            reload  Success
    DONE            disabled 0 obsolete processes   Success
    FAILED          OPENIO-oioproxy-0      No such file or directory
  stdout_lines: <omitted>
...ignoring
```