### PR TITLE
FEATURE(namespace): Fill in the namespace configuration file with database connection information

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -57,4 +57,23 @@ openio_namespace_options:
   - "sqliterepo.repo.hard_max=1000"
 
 openio_namespace_overwrite: false
+
+openio_namespace_redis_inventory_groupname: redis
+openio_namespace_iam_connection:
+  "{% if openio_namespace_redis_inventory_groupname in groups
+        and groups[openio_namespace_redis_inventory_groupname] | length >= 3 -%}
+      redis+sentinel://{{ (groups[openio_namespace_redis_inventory_groupname] \
+        | map('extract', hostvars, ['openio_bind_address']) \
+        | map('regex_replace', '$', ':6012') \
+        | join(',')) \
+        ~ '?sentinel_name=' ~ openio_namespace_name ~ '-master-1' }}
+   {% elif openio_namespace_redis_inventory_groupname in groups
+        and groups[openio_namespace_redis_inventory_groupname] | length == 1 -%}
+      redis://{{ groups[openio_namespace_redis_inventory_groupname] \
+        | map('extract', hostvars, ['openio_bind_address']) \
+        | map('regex_replace', '$', ':6011') \
+        | list | first }}
+   {% endif %}"
+openio_namespace_bucketdb_connection: "{{ openio_namespace_iam_connection }}"
+openio_namespace_container_hierarchy_connection: "{{ openio_namespace_iam_connection }}"
 ...

--- a/docker-tests/checks.bats
+++ b/docker-tests/checks.bats
@@ -19,3 +19,11 @@
   [[ "${status}" -eq "0" ]]
   [[ "${output}" =~ 'zookeeper=172.17.0.2:6005,172.17.0.3:6005,172.17.0.4:6005;172.17.0.5:6005,172.17.0.6:6005,172.17.0.7:6005' ]]
 }
+
+@test 'NAMESPACE - IAM test' {
+  run bash -c "docker exec -ti ${SUT_ID} cat /etc/oio/sds.conf.d/TRAVIS"
+  echo "output: "$output
+  echo "status: "$status
+  [[ "${status}" -eq "0" ]]
+  [[ "${output}" =~ 'iam.connection=redis+sentinel://172.17.0.2:6012,172.17.0.3:6012,172.17.0.4:6012?sentinel_name=TRAVIS-master-1' ]]
+}

--- a/docker-tests/test.yml
+++ b/docker-tests/test.yml
@@ -19,6 +19,19 @@
       run_once: true
       changed_when: false
 
+    - add_host:
+        name: "{{ item.name }}"
+        ansible_host: "{{ item.openio_bind_address }}"
+        openio_bind_address: "{{ item.openio_bind_address }}"
+        groups: redis
+      with_items:
+        - { name: "node1", openio_bind_address: "172.17.0.2" }
+        - { name: "node2", openio_bind_address: "172.17.0.3" }
+        - { name: "node3", openio_bind_address: "172.17.0.4" }
+      delegate_to: localhost
+      run_once: true
+      changed_when: false
+
     #- add_host:
     #    name: "{{ item.name }}"
     #    ansible_host: "{{ item.openio_bind_address }}"
@@ -49,6 +62,7 @@
     - role: repo
       openio_repository_no_log: false
       openio_repository_mirror_host: mirror2.openio.io
+      openio_repository_manage_openstack_repository: false
     - role: role_under_test
       openio_namespace_name: "{{ NS }}"
       openio_namespace_oioproxy_url: "{{ ansible_default_ipv4.address }}:6006"

--- a/templates/namespace.j2
+++ b/templates/namespace.j2
@@ -14,6 +14,11 @@ ns.storage_policy={{ openio_namespace_storage_policy }}
 ns.chunk_size={{ (openio_namespace_chunk_size_megabytes | int) * 1024 * 1024 }}
 ns.service_update_policy={% for servicetype in openio_namespace_service_update_policy %}{{ servicetype.name }}={{ servicetype.policy }}|{{ servicetype.replicas }}|{{ servicetype.distance }}|;{% endfor %}
 
+
+{{ '#' if not openio_namespace_iam_connection else '' }}iam.connection={{ openio_namespace_iam_connection }}
+{{ '#' if not openio_namespace_container_hierarchy_connection else '' }}container_hierarchy.connection={{ openio_namespace_container_hierarchy_connection }}
+{{ '#' if not openio_namespace_bucketdb_connection else '' }}bucket_db.connection={{ openio_namespace_bucketdb_connection }}
+
 {% for option in openio_namespace_options %}
 {{ option }}
 {% endfor %}


### PR DESCRIPTION
 ##### SUMMARY

As for zookeeper, we would like the connection information for the following databases to be defined in the namespace configuration file (/etc/oio/sds.conf.d/*)

* bucket_db `bucket_db.connection`
* container_hierarchy `container_hierarchy.connection`
* IAM `iam.connection`

The values must use the "new" format, including the protocol to use, and optional parameters.

 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION
Examples of output:
* group `redis` of 3 nodes :
```
iam.connection=redis+sentinel://172.17.0.2:6012,172.17.0.3:6012,172.17.0.4:6012?sentinel_name=OPENIO-master-1
container_hierarchy.connection=redis+sentinel://172.17.0.2:6012,172.17.0.3:6012,172.17.0.4:6012?sentinel_name=OPENIO-master-1
bucket_db.connection=redis+sentinel://172.17.0.2:6012,172.17.0.3:6012,172.17.0.4:6012?sentinel_name=OPENIO-master-1
```
* group `redis` of 1 node :
```
iam.connection=redis://172.17.0.2:6011
container_hierarchy.connection=redis://172.17.0.2:6011
bucket_db.connection=redis://172.17.0.2:6011
```
* group `redis` empty :
```
 #iam.connection=
 #container_hierarchy.connection=
 #bucket_db.connection=
```