### PR TITLE
CHANGE(namespace): Add default config for sqliterepo.cache.kbytes_per_db

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -32,6 +32,7 @@ openio_namespace_service_update_policy:
 openio_namespace_options:
   - "sqliterepo.repo.soft_max=1000"
   - "sqliterepo.repo.hard_max=1000"
+  - "sqliterepo.cache.kbytes_per_db=4096"
 
 openio_namespace_overwrite: false
 ...


### PR DESCRIPTION
 ##### SUMMARY
This default value is needed to ensure different versions of sqlite
are behaving in the same way.

 ##### ISSUE TYPE
- Feature Pull Request

 ##### SCOPE (skeleton only)

 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION