### PR TITLE
CHANGE(namespace): Change the default chuncksize to  1 GB

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -41,7 +41,7 @@ openio_namespace_udp_allowed: "yes"
 openio_namespace_provision_only: false
 
 openio_namespace_storage_policy: "{{ namespace_storage_policy | d('THREECOPIES') }}"
-openio_namespace_chunk_size_megabytes: "{{ namespace_chunk_size_megabytes | d(100) | int }}"
+openio_namespace_chunk_size_megabytes: "{{ namespace_chunk_size_megabytes | d(1000) | int }}"
 openio_namespace_service_update_policy:
   - name: meta2
     policy: KEEP


### PR DESCRIPTION
 ##### SUMMARY

Set the default chunksize to 1000 MB to make fewer & bigger uploads and as such reduce per-upload overhead.

 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION
OB-556